### PR TITLE
Исправлено некорректное использование кэша MIME-типов.

### DIFF
--- a/test-app/main.cpp
+++ b/test-app/main.cpp
@@ -5,7 +5,7 @@ void print_mime_type_info(const std::string &mime_type) {
     std::cout << "Mime type: " << mime_type << std::endl;
 
     auto associations = library::get_mime_type_associations(mime_type);
-    std::cout << "Mime apps: " << std::endl;
+    std::cout << "Associations from MIME-database: " << std::endl;
     if (associations.empty()) {
         std::cout << "\tAssociations not found" << std::endl;
     } else {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,15 +1,28 @@
 project(mimes_test)
 find_package(GTest REQUIRED)
 set(SOURCES
-        run_all_tests.cpp
-        helpers/file__is_exists.cpp
-        helpers/path__join.cpp
-        helpers/string__split.cpp
-        mime/mime_cache_parser__parse_string.cpp
-        mime/mime_cache_parser__parse_file.cpp
+        desktop/desktop_parser__parse_file.cpp
         helpers/command__get_command_text.cpp
         helpers/command__execute.cpp
-        helpers/file__get_mime_type.cpp library.cpp mime/mime_applications_parser.cpp mime/mime_cache_builder__from_mime_applications.cpp helpers/path__extract_file_name.cpp desktop/desktop_parser__parse_file.cpp helpers/directory__get_file_names.cpp helpers/string__ends_with.cpp helpers/directory__is_exitst.cpp mime/mime_database_file_parser__parse_file.cpp helpers/string__starts_with.cpp helpers/string__ltrim.cpp helpers/path__extract_file_extension.cpp)
+        helpers/directory__get_file_names.cpp
+        helpers/directory__is_exitst.cpp
+        helpers/file__get_mime_type.cpp
+        helpers/file__is_exists.cpp
+        helpers/path__extract_file_extension.cpp
+        helpers/path__extract_file_name.cpp
+        helpers/path__join.cpp
+        helpers/string__ltrim.cpp
+        helpers/string__ends_with.cpp
+        helpers/string__split.cpp
+        helpers/string__starts_with.cpp
+        mime/mime_applications_parser.cpp
+        mime/mime_cache_builder__apply_overrides.cpp
+        mime/mime_cache_builder__from_mime_applications.cpp
+        mime/mime_cache_parser__parse_file.cpp
+        mime/mime_cache_parser__parse_string.cpp
+        mime/mime_database_file_parser__parse_file.cpp
+        library.cpp
+        run_all_tests.cpp)
 add_executable(mimes_test ${SOURCES})
 target_include_directories(mimes_test PUBLIC ../src ${GTEST_INCLUDE_DIRS})
 target_link_libraries(mimes_test ${GTEST_LIBRARIES} pthread mimes)

--- a/test/mime/mime_cache_builder__apply_overrides.cpp
+++ b/test/mime/mime_cache_builder__apply_overrides.cpp
@@ -1,0 +1,66 @@
+#include <gtest/gtest.h>
+
+#include "mime/mime_applications.hpp"
+#include "mime/mime_cache.hpp"
+#include "mime/mime_cache_builder.hpp"
+
+/**
+ * Имитирует ситуацию, когда в файле /usr/share/applications/mimeapps.list содержится:
+ * [Added Associations]
+ * application/vnd.oasis.opendocument.spreadsheet=calc.desktop;gnumeric.desktop;kf5-org.kde.calligrasheets.desktop;
+ *
+ *
+ * А в файле ~/.config/mimeapps.list содержится:
+ * [Default Applications]
+ * application/vnd.oasis.opendocument.spreadsheet=calc.desktop
+ *
+ * [Added Associations]
+ * application/vnd.oasis.opendocument.spreadsheet=openoffice4-calc.desktop;desktopeditors.desktop;r7-office-desktopeditors.desktop;calc.desktop;myoffice-table.desktop;
+ */
+TEST(mime_cache_builder__apply_overrides, two_files) {
+    // Подготовить системный кэш
+    auto system_cache = new mime::mime_cache();
+    system_cache->associations.insert({
+        "application/vnd.oasis.opendocument.spreadsheet",
+        {
+            "calc.desktop",
+            "gnumeric.desktop",
+            "kf5-org.kde.calligrasheets.desktop"
+        }
+    });
+
+    // Подготовить пользовательское переопределение
+    auto user_applications = new mime::mime_applications();
+    user_applications->default_applications.insert({
+        "application/vnd.oasis.opendocument.spreadsheet",
+        {
+            "calc.desktop",
+        }
+    });
+    user_applications->added_associations.insert({
+        "application/vnd.oasis.opendocument.spreadsheet",
+        {
+            "openoffice4-calc.desktop",
+            "desktopeditors.desktop",
+            "r7-office-desktopeditors.desktop",
+            "calc.desktop",
+            "myoffice-table.desktop"
+        }
+    });
+    mime::mime_cache_builder::apply_overrides(system_cache, user_applications);
+    std::map<std::string, std::vector<std::string>> expected_result = {
+            {
+                    "application/vnd.oasis.opendocument.spreadsheet",
+                    {
+                            "calc.desktop",
+                            "openoffice4-calc.desktop",
+                            "desktopeditors.desktop",
+                            "r7-office-desktopeditors.desktop",
+                            "myoffice-table.desktop",
+                            "gnumeric.desktop",
+                            "kf5-org.kde.calligrasheets.desktop"
+                    }
+            }
+    };
+    ASSERT_EQ(system_cache->associations, expected_result);
+}

--- a/test/mime/mime_cache_builder__from_mime_applications.cpp
+++ b/test/mime/mime_cache_builder__from_mime_applications.cpp
@@ -55,7 +55,7 @@ TEST(mime_cache_builder__from_mime_applications, add_application) {
     auto result = std::shared_ptr<mime::mime_cache>(mime::mime_cache_builder::from_mime_applications(applications));
     delete applications;
     std::map<std::string, std::vector<std::string>> expected_result = {
-            {"text/plain", {"notepad", "gedit"}}
+            {"text/plain", {"gedit", "notepad"}}
     };
     ASSERT_EQ(result->associations, expected_result);
 }
@@ -70,13 +70,45 @@ TEST(mime_cache_builder__from_mime_applications, all_sections) {
     };
     applications->added_associations = {
             {"text/plain", {"vscode"}},
-            {"pdf", {"ocular"}}
+            {"pdf",        {"ocular"}}
     };
     auto result = std::shared_ptr<mime::mime_cache>(mime::mime_cache_builder::from_mime_applications(applications));
     delete applications;
     std::map<std::string, std::vector<std::string>> expected_result = {
             {"text/plain", {"vscode"}},
-            {"pdf", {"ocular"}}
+            {"pdf",        {"ocular"}}
+    };
+    ASSERT_EQ(result->associations, expected_result);
+}
+
+TEST(mime_cache_builder__from_mime_applications, application_in_multiple_sections) {
+    auto applications = new mime::mime_applications();
+    applications->default_applications = {
+            {"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", {"calc.desktop"}}
+    };
+    applications->added_associations = {
+            {
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    {
+                            "openoffice4-calc.desktop",
+                            "r7-office-desktopeditors.desktop",
+                            "calc.desktop",
+                            "myoffice-table.desktop"
+                    }
+            }
+    };
+    auto result = std::shared_ptr<mime::mime_cache>(mime::mime_cache_builder::from_mime_applications(applications));
+    delete applications;
+    std::map<std::string, std::vector<std::string>> expected_result = {
+            {
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    {
+                            "calc.desktop",
+                            "openoffice4-calc.desktop",
+                            "r7-office-desktopeditors.desktop",
+                            "myoffice-table.desktop"
+                    }
+            }
     };
     ASSERT_EQ(result->associations, expected_result);
 }


### PR DESCRIPTION
На ALT Linux некорректно формировался список ассоциированных приложений. После внесенных изменений получается так:
![изображение](https://user-images.githubusercontent.com/42317725/77136888-e34e2c80-6a84-11ea-9a4c-9862232fab5e.png)
В настройках файла выставлено:
![изображение](https://user-images.githubusercontent.com/42317725/77135982-8c485780-6a84-11ea-831d-0bd0831a05fe.png)
